### PR TITLE
Fix missing y,z field names for set_eye_offset() input vector

### DIFF
--- a/resize.lua
+++ b/resize.lua
@@ -27,7 +27,7 @@ entity_modifier.resize_player = function(player, size)
 	else
 		player:set_eye_offset(
 			{x=0, y=0, z=0},
-			{x=0, size * 5, -size}
+			{x=0, y=size * 5, z=-size}
 		)
 		if size >= 4 then
 			jump = 2


### PR DESCRIPTION
When trying /resize or /resizeme, Minetest was crashing with:
```
2021-03-18 15:43:33: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'entity_modifier' in callback on_chat_message(): Invalid position coordinate 'y' (expected number got nil).
2021-03-18 15:43:33: ERROR[Main]: stack traceback:
2021-03-18 15:43:33: ERROR[Main]: 	[C]: in function 'set_eye_offset'
2021-03-18 15:43:33: ERROR[Main]: 	...minetest/bin/../mods/minetest-entity_modifier/resize.lua:28: in function 'resize_player'
2021-03-18 15:43:33: ERROR[Main]: 	...minetest/bin/../mods/minetest-entity_modifier/resize.lua:94: in function 'func'
2021-03-18 15:43:33: ERROR[Main]: 	/home/fil/w/mt/minetest/bin/../builtin/game/chat.lua:76: in function </home/fil/w/mt/minetest/bin/../builtin/game/chat.lua:50>
2021-03-18 15:43:33: ERROR[Main]: 	/home/fil/w/mt/minetest/bin/../builtin/game/register.lua:425: in function </home/fil/w/mt/minetest/bin/../builtin/game/register.lua:409>
```
Added missing y and z field names to vector.